### PR TITLE
Add an option to include all attribute in the diff

### DIFF
--- a/lib/active_record/diff.rb
+++ b/lib/active_record/diff.rb
@@ -32,9 +32,14 @@ module ActiveRecord
         if attrs.nil?
           attrs = self.class.content_columns.map { |column| column.name.to_sym }
         elsif attrs.length == 1 && Hash === attrs.first
-          columns = self.class.content_columns.map { |column| column.name.to_sym }
-
-          attrs = columns + (attrs.first[:include] || []) - (attrs.first[:exclude] || [])
+          options = attrs.first
+          if options[:include] == :all
+            columns = self.class.columns.map { |column| column.name.to_sym }
+            attrs = columns - (options[:exclude] || [])
+          else
+            columns = self.class.content_columns.map { |column| column.name.to_sym }
+            attrs = columns + (options[:include] || []) - (options[:exclude] || [])
+          end
         end
 
         diff_each(attrs) do |attr_name|

--- a/lib/active_record/diff.rb
+++ b/lib/active_record/diff.rb
@@ -34,8 +34,7 @@ module ActiveRecord
         elsif attrs.length == 1 && Hash === attrs.first
           options = attrs.first
           if options[:include] == :all
-            columns = self.class.columns.map { |column| column.name.to_sym }
-            attrs = columns - (options[:exclude] || [])
+            attrs = all_columns - (options[:exclude] || [])
           else
             columns = self.class.content_columns.map { |column| column.name.to_sym }
             attrs = columns + (options[:include] || []) - (options[:exclude] || [])
@@ -58,6 +57,12 @@ module ActiveRecord
 
         diff_hash
       end
+    end
+
+    def all_columns
+      columns = self.class.column_names.map(&:to_sym).reject { |c| self.class.stored_attributes.keys.include?(c) }
+      columns |=  self.class.stored_attributes.values.flatten
+      columns.uniq
     end
   end
 end

--- a/spec/active_record_diff_spec.rb
+++ b/spec/active_record_diff_spec.rb
@@ -8,6 +8,8 @@ ActiveRecord::Schema.define do
   create_table :people do |table|
     table.column :name, :string
     table.column :email_address, :string
+    table.column :company_id, :integer
+    table.column :post_count, :integer
   end
 end
 
@@ -19,9 +21,9 @@ describe 'ActiveRecord::Diff' do
       include ActiveRecord::Diff
     end
 
-    @person.create! :name => 'alice', :email_address => 'alice@example.com'
-    @person.create! :name => 'bob', :email_address => 'bob@example.com'
-    @person.create! :name => 'eve', :email_address => 'bob@example.com'
+    @person.create! :name => 'alice', :email_address => 'alice@example.com', :company_id => 3, :post_count => 5
+    @person.create! :name => 'bob', :email_address => 'bob@example.com', :company_id => 4, :post_count => 0
+    @person.create! :name => 'eve', :email_address => 'bob@example.com', :company_id => 4, :post_count => 0
 
     @people = @person.all
 
@@ -45,6 +47,17 @@ describe 'ActiveRecord::Diff' do
       @person.diff :id, :name
 
       @alice.diff(@bob).must_equal({:id => [1, 2], :name => %w( alice bob )})
+    end
+
+    it 'includes all attributes if specified' do
+      @person.diff :include => :all, :exclude => [:email_address]
+
+      @alice.diff(@bob).must_equal({
+        :id => [1, 2],
+        :name => %w( alice bob ),
+        :company_id => [3, 4],
+        :post_count => [5, 0]
+      })
     end
   end
 


### PR DESCRIPTION
Add an option to include all attributes in the diff

*Example*

```ruby
Model.diff include: :all, exclude: [:id]
```